### PR TITLE
fix keyerror when generate RTS_GMLC.m

### DIFF
--- a/RTS_Data/FormattedData/MATPOWER/script.py
+++ b/RTS_Data/FormattedData/MATPOWER/script.py
@@ -209,12 +209,12 @@ mpc.gencost = ['''
     for i, g in _generators.iterrows():
         gen['model'] = 1
         gen['startup'] = (
-            (g['Start Heat Cold MMBTU'] * g['Fuel Price $/MMBTU']) + g['Non Fuel Start Cost $']
-            if not np.isnan((g['Start Heat Cold MMBTU'] * g['Fuel Price $/MMBTU']) + g['Non Fuel Start Cost $']) else 0.0
+            (g['Start Heat Cold MBTU'] * g['Fuel Price $/MMBTU']) + g['Non Fuel Start Cost $']
+            if not np.isnan((g['Start Heat Cold MBTU'] * g['Fuel Price $/MMBTU']) + g['Non Fuel Start Cost $']) else 0.0
         )
         gen['shutdown'] = (
-            g['Start Heat Cold MMBTU'] * g['Fuel Price $/MMBTU']
-            if not np.isnan(g['Start Heat Cold MMBTU'] * g['Fuel Price $/MMBTU']) else 0.0
+            g['Start Heat Cold MBTU'] * g['Fuel Price $/MMBTU']
+            if not np.isnan(g['Start Heat Cold MBTU'] * g['Fuel Price $/MMBTU']) else 0.0
         )
         gen['cost'] = list()
         gen['cost'] = g['io_cost']


### PR DESCRIPTION
There is an error in the variable name in the script.py file in the RTS_Data/FormattedData/MATPOWER folder.  "g['Start Heat Cold MMBTU']" should be written as "g['Start Heat Cold MBTU'] ". I have fixed this error so that cli.py can run correctly and generate RTS_GMLC.m.  #154 